### PR TITLE
Comparison of losses by masking bottom 10% vs top 10% based on QAGNN attention values

### DIFF
--- a/distribution.py
+++ b/distribution.py
@@ -1,0 +1,15 @@
+import numpy as np
+import os
+import seaborn as sns
+import matplotlib.pyplot as plt
+
+attentions = []
+
+for i in range(611):
+    arr = np.load(os.path.join('batch_attentions', str(i) + '.npy'))
+    print(arr.shape)
+    attentions += np.mean(arr, axis=1).tolist()
+
+plt.figure(figsize=(16, 9))
+sns.distplot(attentions)
+plt.savefig('attention_distribution.jpg')

--- a/eval_qagnn__csqa.sh
+++ b/eval_qagnn__csqa.sh
@@ -31,3 +31,4 @@ python3 -u qagnn.py --dataset $dataset \
       --mode eval_detail \
       --load_model_path saved_models/csqa_model_hf3.4.0.pt \
       $args
+      # --dataset csqa --train_adj data/csqa/graph/train.graph.adj.pk --dev_adj data/csqa/graph/dev.graph.adj.pk --test_adj  data/csqa/graph/test.graph.adj.pk --train_statements data/csqa/statement/train.statement.jsonl --dev_statements  data/csqa/statement/dev.statement.jsonl --test_statements  data/csqa/statement/test.statement.jsonl --save_model --save_dir saved_models --mode eval_detail --load_model_path saved_models/csqa_model_hf3.4.0.pt


### PR DESCRIPTION
Masking done at subgraph level. 

Summary:

Without masking, we have the following (average) loss values:
Dev loss: 0.3380
Test loss: 0.4031

Masking the bottom 10% edges gives the following:

Dev loss: 0.4098
Test loss: 0.4730

While, masking the top 10% edges gives the following:

Dev loss: 0.4076
Test loss: 0.4719

In general, masking 10% edges gives an increase in the loss of the primary task, but attention values do not seem to have an impact for some reason. 